### PR TITLE
use ip if no hostname is reported back

### DIFF
--- a/main.go
+++ b/main.go
@@ -277,10 +277,11 @@ func discoverNetwork(network string, queue chan func(context.Context), exporter 
 				logrus.Info(net.JoinHostPort(ip, port), " is alive")
 				addr, _ := net.LookupAddr(ip) // #nosec
 				hostname := strings.TrimRight(getFirst(addr), ".")
-				if hostname == "" {
-					logrus.Error("missing reverse record for ", ip)
-					continue
-				}
+                                hostname := strings.TrimRight(getFirst(addr), ".")
+                                if hostname == "" {
+                                        logrus.Info("Missing reverse record for ", ip, ",using ip address instead.")
+                                        hostname = ip
+                                }
 				if isVip(hostname) && !strings.HasPrefix(hostname, "k8s-") {
 					logrus.Info("skipping vip ", hostname, ip)
 					continue


### PR DESCRIPTION
Hi there,

for an environment not reporting back any hostnames, it may be usefull to use the ip address instead ignoring the host.